### PR TITLE
fix(getDigit): support more RUTs ending with a 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@
 ```ts
 import {
   clean,
-  format
+  format,
   getDigit,
   isValid,
   validate,
 } from "https://deno.land/x/rutcl/mod.ts";
-
 
 try {
   validate("123456789");

--- a/lib/getDigit.ts
+++ b/lib/getDigit.ts
@@ -8,7 +8,10 @@ function getDigit(dirtyPartialRut: string | number): string {
     0,
   );
   const digit = 11 - (sum % 11);
-  return digit === 10 ? "K" : String(digit);
+
+  if (digit === 11) return "0";
+  if (digit === 10) return "K";
+  return String(digit);
 }
 
 export default getDigit;

--- a/lib/getDigit_test.ts
+++ b/lib/getDigit_test.ts
@@ -10,4 +10,5 @@ Deno.test("getDigit returns expected digit", () => {
   assertEquals(getDigit("16327681"), "K");
   assertEquals(getDigit(16327681), "K");
   assertEquals(getDigit("13_356_201"), "K");
+  assertEquals(getDigit("12328326"), "0");
 });


### PR DESCRIPTION
This is a fix for supporting some RUTs whose validator digit is 0.

Try the RUT "12328326" in an online validator such as [this one](https://validarut.cl/validar), and it will tell you that the verification digit is 0, but the current algorithm said that the verification digit was 11.

I think this is because the sum gave something divisible by 11, so:

`11 - (121 % 11) === 11`